### PR TITLE
Bug/CIOP-114 (Empty date range when selecting multiple cells before non-empty cell)

### DIFF
--- a/app/components/AllocationTable/AllocationGrid.jsx
+++ b/app/components/AllocationTable/AllocationGrid.jsx
@@ -66,6 +66,7 @@ export default function AllocationGrid({ groupBy, columns, data, loading, select
       
         Object.keys(weeks).forEach((weekN) => {
           const period = currentRowData?.[weekN]?.period;
+          // console.log('week:', weekN, 'period:', currentRowData?.[weekN]?.period);
           if (period) {
             StartDate = StartDate ? (isBefore(period, StartDate) ? period : StartDate) : period;
             EndDate = EndDate ? (isAfter(period, EndDate) ? period : EndDate) : period;
@@ -100,20 +101,38 @@ export default function AllocationGrid({ groupBy, columns, data, loading, select
       ...aggregationModel(startDate, endDate),
   });
 
+  const normalizeRow = (row) => {
+    const allWeeks = generateAllWeeks();
+    const normalized = { ...row };
 
-  const normalizeRow = row => {
-    return Object.keys(row).reduce((normalized, key) => {
-      if (key.startsWith('W')) {
-        const weekValue = row[key];
-        normalized[key] =
-          typeof weekValue === 'object' && weekValue !== null
-            ? weekValue
-            : { allocationId: null, value: weekValue };
+    allWeeks.forEach((weekKey) => {
+      const weekNumber = weekKey.slice(1);
+      const period = getMondayOfWeek(weekNumber, new Date());
+
+      const value = row[weekKey];
+
+      if (value && typeof value === 'object' && 'value' in value) {
+        normalized[weekKey] = {
+          allocationId: value.allocationId || null,
+          value: value.value,
+          period: period,
+        };
+      } else if (value !== undefined) {
+        normalized[weekKey] = {
+          allocationId: null,
+          value,
+          period,
+        };
       } else {
-        normalized[key] = row[key];
+        normalized[weekKey] = {
+          allocationId: null,
+          value: null,
+          period,
+        };
       }
-      return normalized;
-    }, {});
+    });
+
+    return normalized;
   };
 
   useEffect(() => {

--- a/app/components/AllocationTable/AllocationGrid.jsx
+++ b/app/components/AllocationTable/AllocationGrid.jsx
@@ -66,7 +66,6 @@ export default function AllocationGrid({ groupBy, columns, data, loading, select
       
         Object.keys(weeks).forEach((weekN) => {
           const period = currentRowData?.[weekN]?.period;
-          // console.log('week:', weekN, 'period:', currentRowData?.[weekN]?.period);
           if (period) {
             StartDate = StartDate ? (isBefore(period, StartDate) ? period : StartDate) : period;
             EndDate = EndDate ? (isAfter(period, EndDate) ? period : EndDate) : period;
@@ -106,8 +105,7 @@ export default function AllocationGrid({ groupBy, columns, data, loading, select
     const normalized = { ...row };
 
     allWeeks.forEach((weekKey) => {
-      const weekNumber = weekKey.slice(1);
-      const period = getMondayOfWeek(weekNumber, new Date());
+      const period = getMondayOfWeek(weekKey, new Date());
 
       const value = row[weekKey];
 

--- a/app/utils/common.js
+++ b/app/utils/common.js
@@ -1,4 +1,4 @@
-import { addDays, eachDayOfInterval, format, getWeek, getYear, setWeek, startOfISOWeek, startOfWeek, subDays, subWeeks, weeksToDays } from 'date-fns';
+import { addDays, eachDayOfInterval, format, getWeek, getYear, setWeek, startOfISOWeek, startOfWeek, subDays, subWeeks, weeksToDays, startOfISOWeekYear } from 'date-fns';
 import { DATE_FORMAT, TOTAL_FUTURE_WEEKS, TOTAL_FUTURE_WEEKS_ARROW } from '../constants/constants';
 
 // Calculate total effort from weekly columns
@@ -64,11 +64,10 @@ export const getMondaysInRange = (start, end) => {
  * @returns {string} - The Monday date of the given week in YYYY-MM-DD format.
  */
 export const getMondayOfWeek = (weekNumber, date) => {
-  const year = getYear(date);
-  const firstDayOfYear = new Date(year, 0, 1);
-  const weekN = typeof weekNumber !== 'number' ? Number(weekNumber.slice(1)) : weekNumber;
-  const dateInWeek = setWeek(firstDayOfYear, weekN);
-  return format(startOfISOWeek(dateInWeek, { weekStartsOn: 1 }), DATE_FORMAT);
+  const year = date.getFullYear();
+  const startOfFirstWeek = startOfISOWeekYear(new Date(year, 0, 1));
+  const mondayOfTargetWeek = addWeeks(startOfFirstWeek, weekNumber - 1);
+  return format(mondayOfTargetWeek, DATE_FORMAT);
 };
 
 export function generateAllMondays(startDate, endDate) {

--- a/app/utils/common.js
+++ b/app/utils/common.js
@@ -64,10 +64,12 @@ export const getMondaysInRange = (start, end) => {
  * @returns {string} - The Monday date of the given week in YYYY-MM-DD format.
  */
 export const getMondayOfWeek = (weekNumber, date) => {
-  const year = date.getFullYear();
-  const startOfFirstWeek = startOfISOWeekYear(new Date(year, 0, 1));
-  const mondayOfTargetWeek = addWeeks(startOfFirstWeek, weekNumber - 1);
-  return format(mondayOfTargetWeek, DATE_FORMAT);
+  const year = getYear(date);
+  const firstDayOfYear = new Date(year, 0, 1);
+  const weekN =
+    typeof weekNumber !== 'number' ? Number(weekNumber.slice(1)) : weekNumber;
+  const dateInWeek = setWeek(firstDayOfYear, weekN);
+  return format(startOfISOWeek(dateInWeek, { weekStartsOn: 1 }), DATE_FORMAT);
 };
 
 export function generateAllMondays(startDate, endDate) {


### PR DESCRIPTION
**Resolved bug where selecting multiple cells before a cell with a value resulted in missing date range in Allocation form.**

- Changed normalizeRow to ensure all cells, containing a value or not, have consistent object format to prevent undefined periods

- Changed getMondayOfWeek to use startOfISOWeekYear() and addWeeks() for accurate ISO week-based Monday dates to prevent incorrect periods

------------------------------------------------

**New Commit: resolved cell update error**

Bug: error when handleCellUpdate calls getMondayOfWeek 

- Reverted getMondayOfWeek back to original (initially I thought this was causing incorrect dates)
- Removed week number string first character “W” slicing in normalizeRow (added in initial commit)
- Initial commit of normalizeRow fixed the bug where multiple cells before a non-empty cell had an empty date range, but also caused date inconsistencies. This was because of using string slicing in normalizeRow to get week number (Ex: “W15” to “15”), which was then passed into getMondayOfWeek which slices the first character, resulting in wrong week number (Ex: “15” to “5”)

Results: Cells now updating properly.


