### PR TITLE
bug/CIORA-547 (End Date after Start Date validation)

### DIFF
--- a/app/components/DatePicker/CustomDatePicker.tsx
+++ b/app/components/DatePicker/CustomDatePicker.tsx
@@ -102,19 +102,14 @@ export default function CustomDatePicker({
   let minDate: Dayjs | undefined = undefined;
   let maxDate: Dayjs | undefined = undefined;
 
-  if (name === 'StartDate' && values.endDate) {
-    const end = dayjs(values.endDate);
-    maxDate = end.isValid()
-      ? end.isAfter(dayjs())
-        ? end.subtract(0, 'day')
-        : end
-      : undefined;
-    minDate = end.subtract(1, 'year');
+  if (name === 'StartDate') {
+    const end = values.EndDate ? dayjs(values.EndDate) : null;
+    maxDate = end?.isValid() ? end.startOf('day') : undefined;
   }
 
-  if (name === 'EndDate' && values.startDate) {
-    const start = dayjs(values.startDate);
-    minDate = start;
+  if (name === 'EndDate') {
+    const start = values.StartDate ? dayjs(values.StartDate) : dayjs();
+    minDate = start.startOf('day');
     maxDate = start.add(1, 'year');
   }
 

--- a/app/components/Forms/ValidationSchema.tsx
+++ b/app/components/Forms/ValidationSchema.tsx
@@ -69,10 +69,24 @@ export const addResourceValidationSchema = Yup.object({
   Manager: Yup.string().required('Manager is required'),
   ContractorHourlyRate: Yup.number().nullable().typeError('Must be a number'),
   AverageWeeklyHours: Yup.number().nullable().typeError('Must be a number'),
-  EndDate: Yup.string().when('Status', {
-    is: 'Inactive',
-    then: (schema) => schema.required('End Date is required'),
-    otherwise: (schema) => schema.notRequired(),
+  EndDate: Yup.string()
+  .nullable()
+  .when(['Status', 'StartDate'], {
+    is: (status: String) => status === 'Inactive',
+    then: (schema) =>
+      schema
+        .required('End Date is required')
+        .test('end-after-start', 'End Date cannot be before Start Date', function (endDate) {
+          const { StartDate } = this.parent;
+          if (!endDate || !StartDate) return true;
+          return new Date(endDate) >= new Date(StartDate);
+        }),
+    otherwise: (schema) =>
+      schema.test('end-after-start', 'End Date cannot be before Start Date', function (endDate) {
+        const { StartDate } = this.parent;
+        if (!endDate || !StartDate) return true;
+        return new Date(endDate) >= new Date(StartDate);
+      }),
   }),
 });
 


### PR DESCRIPTION
Changed End Date validation to ensure it cannot be before Start Date

New Commit:
- Grey out all days before current day when selecting End Date, if Start Date is empty
- Grey out all days after End Date when selecting Start Date, to prevent Start Date after End Date
- If Start Date is before current date, then End Date can be before current date as long as it's still after End Date