### PR TITLE
bug/CIORA-546 (API error response on Resource Form submission)

### DIFF
--- a/app/components/AllocationTable/components/AllocationForm.jsx
+++ b/app/components/AllocationTable/components/AllocationForm.jsx
@@ -383,6 +383,18 @@ const AllocationForm = () => {
 
         try {
           const result = await dispatch(addResource(postData));
+          if (result.meta.requestStatus === 'rejected') {
+            dispatch(
+              showToast({
+                open: true,
+                message: `Failed to add resource`,
+                type: 'error',
+                position: 'bottom-left',
+                autoHideTimer: 4000,
+              })
+            );
+            return;
+          }
           const newResourceId = result?.payload?.result?.Id ?? null;
 
           if (newResourceId) {

--- a/app/components/Forms/AddResourceForm.jsx
+++ b/app/components/Forms/AddResourceForm.jsx
@@ -212,7 +212,12 @@ const AddResourceForm = ({ formikProps , setFormValue}) => {
             name="HRLevel"
             placeholder="Enter level"
             value={values.HRLevel || ''}
-            onChange={handleChange}
+            onChange={(e) => {
+              const input = e.target.value;
+              if (/^\d*$/.test(input)) {
+                formikProps.setFieldValue('HRLevel', input);
+              }
+            }}
             onBlur={handleBlur}
             error={touched.HRLevel && Boolean(errors.HRLevel)}
             helperText={touched.HRLevel && errors.HRLevel}


### PR DESCRIPTION
- Added API error response on Add Resource form submission 
- updated HRLevel field onChange to only take non-negative whole numbers

Currently HR Level is stored as a string in the backend, so the validation schema is still Yup.string()