### PR TITLE
bug/StartDateTeamField

### DIFF
--- a/app/components/AllocationTable/components/AllocationForm.jsx
+++ b/app/components/AllocationTable/components/AllocationForm.jsx
@@ -97,7 +97,7 @@ const initialValuesMap = {
     AverageWeeklyHours: null,
     Team: '',
     Manager: '',
-    StartDate: parseISO(new Date().toISOString()),
+    StartDate: new Date().toISOString().split('T')[0],
     EndDate: '',
     WorkLocation: '',
     Status: '',

--- a/app/components/Forms/AddResourceForm.jsx
+++ b/app/components/Forms/AddResourceForm.jsx
@@ -51,7 +51,7 @@ const AddResourceForm = ({ formikProps, setFormValue }) => {
     })) || [];
   const teamListOptions =
     teams?.result?.map(team => ({
-      value: team.Name,
+      value: team.__path__,
       label: team.Name,
     })) || [];
   const dispatch = useDispatch();
@@ -89,7 +89,7 @@ const AddResourceForm = ({ formikProps, setFormValue }) => {
         Role: initialData.Role || '',
         PhoneNumber: initialData.PhoneNumber || '',
         LocationCategory: initialData.LocationCategory || '',
-        Team: initialData.Team || '',
+        Team: teams?.result?.find(team => team.Name === initialData.Team)?.__path__ || '',
         Organisation: initialData.Organization || '',
       };
 


### PR DESCRIPTION
- Bug: StartDate is invalid on Resource form submit due to having time in string
  - Changed StartDate initial value to be date-only string
- Bug: Resource not being assigned to chosen Team on form submit (receiving team name instead of path when calling API)
  - Changed TeamListOptions value back to path instead of team name
  - In useEffect for edit_resource, changed Team to search for path of resource’s Team, displays Team name of matching path
