### PR TITLE
bug/CIORA-660 (fixed inconsistent End Date requirement in edit_resource)

### DIFF
--- a/app/components/Forms/AddResourceForm.jsx
+++ b/app/components/Forms/AddResourceForm.jsx
@@ -485,7 +485,7 @@ const AddResourceForm = ({ formikProps, setFormValue }) => {
           label="End Date"
           placeholder="MM/DD/YYYY"
           title="End Date"
-          isRequired={true}
+          isRequired={false}
         />
       </Box>
       <Box sx={{ flex: 1 }}>

--- a/app/components/Forms/ValidationSchema.tsx
+++ b/app/components/Forms/ValidationSchema.tsx
@@ -138,7 +138,6 @@ export const editResourceValidationSchema = Yup.object({
       is: (status: String) => status === 'Inactive',
       then: schema =>
         schema
-          .required('End Date is required')
           .test(
             'end-after-start',
             'End Date cannot be before Start Date',


### PR DESCRIPTION
**CIORA-660: Inconsistent Requirement for End Date Field Between Add and Edit Resource Forms for the Inactive resource**
- made End Date no longer required when Status is Inactive, in editResourceValidationSchema
- removed red asterisk from End Date field when Resource is Inactive