### PR TITLE
enhance/CIORA-647 (Same column menu items in all columns)

### DIFF
--- a/app/components/AllocationTable/components/CustomColumnMenu.jsx
+++ b/app/components/AllocationTable/components/CustomColumnMenu.jsx
@@ -23,7 +23,7 @@ const StyledPopper = styled(GridColumnMenu)(({ theme }) => ({
   },
 }));
 
-const CustomUserMenuItems = ({ apiRef }) => {
+const CustomUserMenuItems = ({ apiRef, field }) => {
   const [teamsExpanded, setTeamsExpanded] = useState(true);
   const [resourcesExpanded, setResourcesExpanded] = useState(false);
   const view = useSelector(state => state.allocationView.view);
@@ -114,22 +114,39 @@ const CustomUserMenuItems = ({ apiRef }) => {
 
   return (
     <>
-      <MenuItem onClick={handleToggleTeams}>
-        <ListItemIcon>
-          <GroupIcon fontSize="small" />
-        </ListItemIcon>
-        <ListItemText>
-          {teamsExpanded
-            ? view === 'Project'
-              ? 'Collapse All Projects'
-              : 'Collapse All Teams'
-            : view === 'Project'
-              ? 'Expand All Projects'
-              : 'Expand All Teams'}
-        </ListItemText>
-      </MenuItem>
+      {(field === '__row_group_by_columns_group_teams__' || field === '__row_group_by_columns_group__') && (
+        <>
+          <MenuItem onClick={handleToggleTeams}>
+            <ListItemIcon>
+              <GroupIcon fontSize="small" />
+            </ListItemIcon>
+            <ListItemText>
+              {teamsExpanded
+                ? view === 'Project'
+                  ? 'Collapse All Projects'
+                  : 'Collapse All Teams'
+                : view === 'Project'
+                  ? 'Expand All Projects'
+                  : 'Expand All Teams'}
+            </ListItemText>
+          </MenuItem>
 
-      {view !== 'Project' && (
+          {view !== 'Project' && (
+            <MenuItem onClick={handleToggleResources}>
+              <ListItemIcon>
+                <PersonIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText>
+                {resourcesExpanded
+                  ? 'Collapse All Resources'
+                  : 'Expand All Resources'}
+              </ListItemText>
+            </MenuItem>
+          )}
+        </>
+      )}
+
+      {field === '__row_group_by_columns_group_resource__' && view !== 'Project' && (
         <MenuItem onClick={handleToggleResources}>
           <ListItemIcon>
             <PersonIcon fontSize="small" />
@@ -147,21 +164,32 @@ const CustomUserMenuItems = ({ apiRef }) => {
 
 export const CustomColumnMenu = props => {
   const { apiRef, ...otherProps } = props;
+  const field = props.colDef?.field;
+  const showUserItem =
+    field === '__row_group_by_columns_group_teams__' ||
+    field === '__row_group_by_columns_group__' ||
+    field === '__row_group_by_columns_group_resource__';
 
   return (
     <StyledPopper
       {...otherProps}
       slots={{
         ...GRID_COLUMN_MENU_SLOTS,
-        columnMenuUserItem: () => <CustomUserMenuItems apiRef={apiRef} />,
+        ...(showUserItem && {
+          columnMenuUserItem: () => (
+            <CustomUserMenuItems apiRef={apiRef} field={field} />
+          ),
+        }),
         columnMenuSortItem: null,
         columnMenuAggregationItem: null,
         columnMenuGroupingItem: null,
       }}
       slotProps={{
-        columnMenuUserItem: {
-          displayOrder: 0,
-        },
+        ...(showUserItem && {
+          columnMenuUserItem: {
+            displayOrder: 0,
+          },
+        }),
         columnMenuColumnsItem: {
           displayOrder: 2,
         },

--- a/app/components/AllocationTable/components/CustomColumnMenu.jsx
+++ b/app/components/AllocationTable/components/CustomColumnMenu.jsx
@@ -124,14 +124,18 @@ const CustomUserMenuItems = ({ apiRef, field }) => {
               {teamsExpanded
                 ? view === 'Project'
                   ? 'Collapse All Projects'
-                  : 'Collapse All Teams'
+                  : view === 'Project Cost'
+                    ? 'Collapse All Projects'
+                    : 'Collapse All Teams'
                 : view === 'Project'
                   ? 'Expand All Projects'
-                  : 'Expand All Teams'}
+                  : view === 'Project Cost'
+                    ? 'Expand All Projects'
+                    : 'Expand All Teams'}
             </ListItemText>
           </MenuItem>
 
-          {view !== 'Project' && (
+          {(view === 'Teams' || view === 'Teams Cost') && field === '__row_group_by_columns_group_teams__' && (
             <MenuItem onClick={handleToggleResources}>
               <ListItemIcon>
                 <PersonIcon fontSize="small" />
@@ -146,7 +150,7 @@ const CustomUserMenuItems = ({ apiRef, field }) => {
         </>
       )}
 
-      {field === '__row_group_by_columns_group_resource__' && view !== 'Project' && (
+      {field === '__row_group_by_columns_group_resource__' && (view === 'Teams' || view === 'Teams Cost') && (
         <MenuItem onClick={handleToggleResources}>
           <ListItemIcon>
             <PersonIcon fontSize="small" />
@@ -160,8 +164,7 @@ const CustomUserMenuItems = ({ apiRef, field }) => {
       )}
     </>
   );
-};
-
+}
 export const CustomColumnMenu = props => {
   const { apiRef, ...otherProps } = props;
   const field = props.colDef?.field;


### PR DESCRIPTION
**CIORA-647: All columns have the same custom menu configurations**

- added field conditions to column menus:
  - Show Team and Resource expand/collapse in Team column
  - Show only Resource expand/collapse in Resource column
  - In Projects view, only Project column has Project collapse/expand
  - Other columns do not have expand/collapse

- added condition to avoid rendering custom menu items if the column is not Team, Resource, or Project, to prevent visual bug (grey line and small white space at top of column menu)

**New Commit:**
- Fixed Project Cost screen having Teams and Resource toggle, now only has one Project toggle for Project Name column. All other views have relavent toggles in corresponding columns.