### PR TITLE
If userId is null (not found in resources list) then GET_ACTUAL_STATU…

### DIFF
--- a/app/(root)/actuals/page.tsx
+++ b/app/(root)/actuals/page.tsx
@@ -323,7 +323,7 @@ function ActualsPage({ permissions, loadingPermissions }: ActualsPageProps) {
           type: GET_ACTUAL_STATUS,
           payload: {
             resource: userId,
-            status: ['In-Progress', 'Not Started'],
+            status: userId ? ['In-Progress', 'Not Started'] : [''],
             startDate:
               generateDateWeekMath('WEEK_MINUS', 7, parseISO(startDate)) || '',
             endDate:


### PR DESCRIPTION
…S is searching for status ['']