### PR TITLE
The need for FETCH_ALL_ALLOCATIONS_INIT is redundant, hence replaced …

### DIFF
--- a/app/(root)/allocation/init.tsx
+++ b/app/(root)/allocation/init.tsx
@@ -167,7 +167,7 @@ function AllocationInit({
       ) {
         dispatch(resetAllocations());
         dispatch({
-          type: 'FETCH_ALL_ALLOCATIONS_INIT',
+          type: 'FETCH_ALL_ALLOCATIONS',
           payload: {
             teams: teams,
             projects: projects,


### PR DESCRIPTION
…it with FETCH_ALL_ALLOCATIONS.